### PR TITLE
Add example personal pages

### DIFF
--- a/src/components/layout/BaseNavigation.astro
+++ b/src/components/layout/BaseNavigation.astro
@@ -6,6 +6,9 @@ interface Props {
 const navigationItems = [
   { name: 'Home', url: '/' },
   { name: 'Blog', url: '/blog/' },
+  { name: 'Projects', url: '/projects/' },
+  { name: 'Resume', url: '/resume/' },
+  { name: 'Contact', url: '/contact/' },
 ];
 
 const socialIcons = [
@@ -66,6 +69,9 @@ const { pageTitle } = Astro.props;
     <h2 class='hidden'>Mobile Navigation</h2>
     <ul>
       <li><a href='/blog/'>Blog</a></li>
+      <li><a href='/projects/'>Projects</a></li>
+      <li><a href='/resume/'>Resume</a></li>
+      <li><a href='/contact/'>Contact</a></li>
     </ul>
   </nav>
 </header>

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -1,0 +1,21 @@
+---
+import Layout from '@layouts/Default.astro';
+---
+
+<Layout title='Contact' pageTitle='Contact' description='How to reach Thomas Grice'>
+  <main class='bg-blue p-6'>
+    <h2 class='text-3xl md:text-5xl dm-serif'>Thomas Grice</h2>
+    <p class='poppins mt-2'>Software engineer, urbanist, filmmaker</p>
+    <p class='poppins mt-2'>Email: <a href='mailto:example@example.com'>example@example.com</a></p>
+
+    <section class='mt-8'>
+      <h3 class='text-2xl dm-serif'>Urbanism Links</h3>
+      <ul class='list-disc pl-4 poppins'>
+        <li><a href='https://substack.example.com' target='_blank'>Substack</a></li>
+        <li><a href='https://youtube.com/example' target='_blank'>YouTube</a></li>
+        <li><a href='https://instagram.com/example' target='_blank'>Instagram</a></li>
+        <li><a href='https://tiktok.com/@example' target='_blank'>TikTok</a></li>
+      </ul>
+    </section>
+  </main>
+</Layout>

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -5,16 +5,17 @@ import Layout from '@layouts/Default.astro';
 <Layout title='Contact' pageTitle='Contact' description='How to reach Thomas Grice'>
   <main class='bg-blue p-6'>
     <h2 class='text-3xl md:text-5xl dm-serif'>Thomas Grice</h2>
-    <p class='poppins mt-2'>Software engineer, urbanist, filmmaker</p>
-    <p class='poppins mt-2'>Email: <a href='mailto:example@example.com'>example@example.com</a></p>
+    <p class='poppins mt-2'>Software engineer, urbanist, aspiring filmmaker</p>
+    <p class='poppins mt-2'>Email: <a href='mailto:augustus.grice@gmail.com'>augustus.grice@gmail.com</a></p>
 
     <section class='mt-8'>
-      <h3 class='text-2xl dm-serif'>Urbanism Links</h3>
+      <h3 class='text-2xl dm-serif'>Links</h3>
       <ul class='list-disc pl-4 poppins'>
-        <li><a href='https://substack.example.com' target='_blank'>Substack</a></li>
-        <li><a href='https://youtube.com/example' target='_blank'>YouTube</a></li>
-        <li><a href='https://instagram.com/example' target='_blank'>Instagram</a></li>
-        <li><a href='https://tiktok.com/@example' target='_blank'>TikTok</a></li>
+        <li><a href='https://www.linkedin.com/in/thomas-grice/' target='_blank'>LinkedIn</a></li>
+        <li><a href='https://urbancowboy.substack.com/' target='_blank'>Urban Cowboy Substack</a></li>
+        <li><a href='https://www.youtube.com/@urbanxcowboy' target='_blank'>Urban Cowboy YouTube</a></li>
+        <li><a href='https://www.instagram.com/urbanxcowboy' target='_blank'>Urban Cowboy Instagram</a></li>
+        <li><a href='https://www.tiktok.com/@urbanxcowboy' target='_blank'>Urban Cowboy TikTok</a></li>
       </ul>
     </section>
   </main>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -5,13 +5,13 @@ import placeholder from '@assets/astro.jpeg';
 
 const projects = [
   {
-    title: 'Example Project One',
-    description: 'Short blurb about this software project.',
+    title: 'Circlepop',
+    description: 'Proof of concept for a transit and population density map within a given radius',
     img: placeholder,
   },
   {
-    title: 'Example Project Two',
-    description: 'Another blurb describing a different project.',
+    title: 'Careernova',
+    description: 'A platform for job seekers to tailor their resume to a given job description',
     img: placeholder,
   },
 ];

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,33 @@
+---
+import Layout from '@layouts/Default.astro';
+import SummaryCard from '@components/generic/SummaryCard.astro';
+import placeholder from '@assets/astro.jpeg';
+
+const projects = [
+  {
+    title: 'Example Project One',
+    description: 'Short blurb about this software project.',
+    img: placeholder,
+  },
+  {
+    title: 'Example Project Two',
+    description: 'Another blurb describing a different project.',
+    img: placeholder,
+  },
+];
+---
+
+<Layout title='Projects' pageTitle='Software Projects' description='Software projects by Thomas Grice'>
+  <main class='bg-purple p-6'>
+    <h2 class='text-3xl md:text-5xl dm-serif mb-4'>Software Projects</h2>
+    <ul class='grid md:grid-cols-2 gap-8'>
+      {
+        projects.map((proj) => (
+          <li>
+            <SummaryCard title={proj.title} imgSrc={proj.img} imgAlt={proj.title} description={proj.description} />
+          </li>
+        ))
+      }
+    </ul>
+  </main>
+</Layout>

--- a/src/pages/resume/index.astro
+++ b/src/pages/resume/index.astro
@@ -1,0 +1,37 @@
+---
+import Layout from '@layouts/Default.astro';
+---
+
+<Layout title='Resume' pageTitle='Resume' description='Thomas Grice Resume'>
+  <main class='bg-yellow p-6'>
+    <h2 class='text-3xl md:text-5xl dm-serif'>Resume</h2>
+    <p class='poppins mt-2'>Below you can switch between a short overview and a detailed resume.</p>
+    <div class='my-4'>
+      <button id='resumeToggle' class='border-2 border-black px-4 py-2 bg-white card-shadow'>Show detailed resume</button>
+    </div>
+    <section id='abridged'>
+      <h3 class='text-2xl dm-serif'>Abridged</h3>
+      <p class='poppins'>This section contains a short one-page style overview.</p>
+    </section>
+    <section id='detailed' style='display:none;'>
+      <h3 class='text-2xl dm-serif'>Detailed</h3>
+      <p class='poppins'>This section contains the extended resume with more information.</p>
+    </section>
+  </main>
+  <script>
+    const btn = document.getElementById('resumeToggle');
+    const abr = document.getElementById('abridged');
+    const det = document.getElementById('detailed');
+    btn?.addEventListener('click', () => {
+      if (det.style.display === 'none') {
+        det.style.display = 'block';
+        abr.style.display = 'none';
+        btn.textContent = 'Show abridged resume';
+      } else {
+        det.style.display = 'none';
+        abr.style.display = 'block';
+        btn.textContent = 'Show detailed resume';
+      }
+    });
+  </script>
+</Layout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       "@components/*": ["src/components/*"],
       "@layouts/*": ["src/layouts/*"],
       "@pages/*": ["src/pages/*"],
+      "@assets/*": ["src/assets/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add contact page with info and urbanism links
- add printable resume with abridged and detailed toggle
- add projects page showing stub software projects
- include new navigation links

## Testing
- `pnpm build` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_6887ca4eaf40832fb30ed6ef74988d03