### PR TITLE
Fix podcast icon and email layout

### DIFF
--- a/src/components/layout/BaseNavigation.astro
+++ b/src/components/layout/BaseNavigation.astro
@@ -23,7 +23,7 @@ const socialIcons = [
   {
     name: 'Pocket Casts',
     url: 'https://pocketcasts.com/podcasts/c5f57c50-4b30-013e-59f9-0eb76ff9618b',
-    icon: 'i-logos:pocketcasts-icon',
+    icon: 'i-logos:pocket-casts-icon',
   },
 ];
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,10 @@ import Layout from '@layouts/Default.astro';
 <Layout title='Home' pageTitle='Home' description='How to reach Thomas Augustus Grice'>
   <main class='bg-blue p-6'>
     <p class='poppins mt-2'>Software engineer, urbanist, aspiring filmmaker</p>
-    <p class='poppins mt-2'>Email: <a href='mailto:augustus.grice@gmail.com'>augustus.grice@gmail.com</a></p>
+    <p class='poppins mt-2 flex items-center gap-2'>
+      <span class='i-uil-envelope w-4 h-4 inline-block'></span>
+      <a href='mailto:augustus.grice@gmail.com'>augustus.grice@gmail.com</a>
+    </p>
 
     <section class='mt-8'>
       <h3 class='text-2xl dm-serif'>Links</h3>


### PR DESCRIPTION
## Summary
- fix podcast icon name to display properly
- display a mail icon next to email on home page

## Testing
- `pnpm run build` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_688a572a40d0832fb32acec8189e3cbf