### PR TITLE
Add reusable project pages with carousel

### DIFF
--- a/src/components/generic/SummaryCard.astro
+++ b/src/components/generic/SummaryCard.astro
@@ -1,15 +1,25 @@
 ---
 import { Card } from '@eliancodes/brutal-ui';
 import { Image } from 'astro:assets';
+import type { ImageMetadata } from 'astro:assets';
 
 interface Props {
   title: string;
   imgSrc: ImageMetadata;
   imgAlt: string;
   description: string;
+  href?: string;
+  linkText?: string;
 }
 
-const { title, imgAlt, imgSrc, description } = Astro.props;
+const {
+  title,
+  imgAlt,
+  imgSrc,
+  description,
+  href,
+  linkText = 'Learn more \u2192',
+} = Astro.props;
 ---
 
 <Card color='white'>
@@ -25,4 +35,11 @@ const { title, imgAlt, imgSrc, description } = Astro.props;
   </div>
   <p class='poppins'>{description}</p>
   <slot />
+  {href && (
+    <div class='flex justify-end mt-4'>
+      <a href={href} class='border-2 border-black px-4 py-2 bg-white card-shadow'>
+        {linkText}
+      </a>
+    </div>
+  )}
 </Card>

--- a/src/components/project/ImageCarousel.astro
+++ b/src/components/project/ImageCarousel.astro
@@ -1,0 +1,50 @@
+---
+import { Image } from 'astro:assets';
+import type { ImageMetadata } from 'astro:assets';
+
+interface Props {
+  images: ImageMetadata[];
+}
+
+const { images } = Astro.props;
+---
+
+<div class='carousel'>
+  {images.map((img, idx) => (
+    <div class:list={[ 'carousel-img', idx !== 0 && 'hidden' ]}>
+      <Image src={img} alt='' width={800} height={400} class='rounded border-2 border-black w-full h-64 object-cover' />
+    </div>
+  ))}
+  {images.length > 1 && (
+    <div class='flex justify-between mt-2'>
+      <button class='prev border-2 border-black px-4 py-2 bg-white card-shadow'>Prev</button>
+      <button class='next border-2 border-black px-4 py-2 bg-white card-shadow'>Next</button>
+    </div>
+  )}
+</div>
+
+<script>
+  document.addEventListener('astro:page-load', () => {
+    const carousel = document.currentScript?.parentElement;
+    if (!carousel) return;
+    const imgs = carousel.querySelectorAll('.carousel-img');
+    if (imgs.length === 0) return;
+    let current = 0;
+    const show = () => {
+      imgs.forEach((el, i) => {
+        el.style.display = i === current ? 'block' : 'none';
+      });
+    };
+    show();
+    const prev = carousel.querySelector('.prev');
+    const next = carousel.querySelector('.next');
+    prev?.addEventListener('click', () => {
+      current = (current - 1 + imgs.length) % imgs.length;
+      show();
+    });
+    next?.addEventListener('click', () => {
+      current = (current + 1) % imgs.length;
+      show();
+    });
+  });
+</script>

--- a/src/layouts/Project.astro
+++ b/src/layouts/Project.astro
@@ -1,0 +1,38 @@
+---
+import Layout from './Default.astro';
+import ImageCarousel from '@components/project/ImageCarousel.astro';
+import type { ImageMetadata } from 'astro:assets';
+
+interface Props {
+  title: string;
+  description: string;
+  images?: ImageMetadata[];
+  mainClass?: string;
+  href?: string;
+  linkText?: string;
+}
+
+const {
+  title,
+  description,
+  images = [],
+  mainClass = 'bg-blue p-6',
+  href,
+  linkText = 'View site \u2192',
+} = Astro.props;
+---
+
+<Layout title={title} pageTitle={title} description={description}>
+  <main class={mainClass}>
+    <h2 class='text-3xl md:text-5xl dm-serif mb-4'>{title}</h2>
+    {href && (
+      <div class='my-4'>
+        <a href={href} class='border-2 border-black px-4 py-2 bg-white card-shadow'>
+          {linkText}
+        </a>
+      </div>
+    )}
+    {images.length > 0 && <ImageCarousel images={images} />}
+    <slot />
+  </main>
+</Layout>

--- a/src/pages/projects/careernova/index.astro
+++ b/src/pages/projects/careernova/index.astro
@@ -1,0 +1,17 @@
+---
+import ProjectLayout from '@layouts/Project.astro';
+import placeholder from '@assets/astro.jpeg';
+
+const images = [placeholder, placeholder];
+---
+
+<ProjectLayout
+  title='Careernova'
+  description='About Careernova'
+  images={images}
+  mainClass='bg-blue p-6'
+  href='https://example.com'
+  linkText='Visit site \u2192'
+>
+  <p class='poppins mt-4'>This is a stub page for the Careernova project. More information will be added later.</p>
+</ProjectLayout>

--- a/src/pages/projects/circlepop/index.astro
+++ b/src/pages/projects/circlepop/index.astro
@@ -1,0 +1,17 @@
+---
+import ProjectLayout from '@layouts/Project.astro';
+import placeholder from '@assets/astro.jpeg';
+
+const images = [placeholder];
+---
+
+<ProjectLayout
+  title='Circlepop'
+  description='About Circlepop'
+  images={images}
+  mainClass='bg-blue p-6'
+  href='https://example.com'
+  linkText='Visit site \u2192'
+>
+  <p class='poppins mt-4'>This is a stub page for the Circlepop project. More information will be added later.</p>
+</ProjectLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -8,11 +8,13 @@ const projects = [
     title: 'Circlepop',
     description: 'Proof of concept for a transit and population density map within a given radius',
     img: placeholder,
+    slug: 'circlepop',
   },
   {
     title: 'Careernova',
     description: 'A platform for job seekers to tailor their resume to a given job description',
     img: placeholder,
+    slug: 'careernova',
   },
 ];
 ---
@@ -24,7 +26,14 @@ const projects = [
       {
         projects.map((proj) => (
           <li>
-            <SummaryCard title={proj.title} imgSrc={proj.img} imgAlt={proj.title} description={proj.description} />
+            <SummaryCard
+              title={proj.title}
+              imgSrc={proj.img}
+              imgAlt={proj.title}
+              description={proj.description}
+              href={`/projects/${proj.slug}/`}
+              linkText='View project \u2192'
+            />
           </li>
         ))
       }


### PR DESCRIPTION
## Summary
- create reusable `Project` layout for project pages
- add `ImageCarousel` component
- stub out Circlepop and Careernova pages using the new layout
- link project summaries to dedicated pages
- add optional link props to `SummaryCard` and `Project` layout

## Testing
- `pnpm build` *(fails: Request was cancelled due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_688ae04cc2c8832f932050464e5fd4ec