### PR TITLE
Fix carousel init and replace podcast icon

### DIFF
--- a/src/components/layout/BaseNavigation.astro
+++ b/src/components/layout/BaseNavigation.astro
@@ -23,7 +23,7 @@ const socialIcons = [
   {
     name: 'Pocket Casts',
     url: 'https://pocketcasts.com/podcasts/c5f57c50-4b30-013e-59f9-0eb76ff9618b',
-    icon: 'i-logos:pocket-casts-icon',
+    icon: 'i-uil:rss-alt',
   },
 ];
 

--- a/src/components/project/ImageCarousel.astro
+++ b/src/components/project/ImageCarousel.astro
@@ -24,7 +24,7 @@ const { images } = Astro.props;
 </div>
 
 <script>
-  document.addEventListener('astro:page-load', () => {
+  const initCarousel = () => {
     const carousel = document.currentScript?.parentElement;
     if (!carousel) return;
     const imgs = carousel.querySelectorAll('.carousel-img');
@@ -47,5 +47,11 @@ const { images } = Astro.props;
       current = (current + 1) % imgs.length;
       show();
     });
-  });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCarousel);
+  } else {
+    initCarousel();
+  }
 </script>


### PR DESCRIPTION
## Summary
- fix carousel script to run after DOM is ready
- replace missing pocket casts icon with rss symbol

## Testing
- `pnpm build` *(fails: The collection "blog" does not exist or is empty)*

------
https://chatgpt.com/codex/tasks/task_e_688b8e5370bc832fbe5e328f00c65035