### PR TITLE
Fix project image carousel with Splide

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@astrojs/rss": "^4.0.12",
     "@astrojs/sitemap": "^3.4.1",
     "@eliancodes/brutal-ui": "^0.2.3",
+    "@splidejs/splide": "^4.1.4",
     "@unocss/astro": "^0.57.7",
     "astro": "^5.12.1",
     "astro-font": "^0.0.80",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@eliancodes/brutal-ui':
     specifier: ^0.2.3
     version: 0.2.3
+  '@splidejs/splide':
+    specifier: ^4.1.4
+    version: 4.1.4
   '@unocss/astro':
     specifier: ^0.57.7
     version: 0.57.7(vite@5.4.10)
@@ -1850,6 +1853,10 @@ packages:
     dependencies:
       fflate: 0.7.4
       string.prototype.codepointat: 0.2.1
+    dev: false
+
+  /@splidejs/splide@4.1.4:
+    resolution: {integrity: sha512-5I30evTJcAJQXt6vJ26g2xEkG+l1nXcpEw4xpKh0/FWQ8ozmAeTbtniVtVmz2sH1Es3vgfC4SS8B2X4o5JMptA==}
     dev: false
 
   /@swc/helpers@0.5.17:

--- a/src/components/project/ImageCarousel.astro
+++ b/src/components/project/ImageCarousel.astro
@@ -1,6 +1,8 @@
 ---
 import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro:assets';
+import Splide from '@splidejs/splide';
+import '@splidejs/splide/css';
 
 interface Props {
   images: ImageMetadata[];
@@ -9,44 +11,25 @@ interface Props {
 const { images } = Astro.props;
 ---
 
-<div class='carousel'>
-  {images.map((img, idx) => (
-    <div class:list={[ 'carousel-img', idx !== 0 && 'hidden' ]}>
-      <Image src={img} alt='' width={800} height={400} class='rounded border-2 border-black w-full h-64 object-cover' />
-    </div>
-  ))}
-  {images.length > 1 && (
-    <div class='flex justify-between mt-2'>
-      <button class='prev border-2 border-black px-4 py-2 bg-white card-shadow'>Prev</button>
-      <button class='next border-2 border-black px-4 py-2 bg-white card-shadow'>Next</button>
-    </div>
-  )}
+<div class='splide'>
+  <div class='splide__track'>
+    <ul class='splide__list'>
+      {images.map((img) => (
+        <li class='splide__slide'>
+          <Image src={img} alt='' width={800} height={400} class='rounded border-2 border-black w-full h-64 object-cover' />
+        </li>
+      ))}
+    </ul>
+  </div>
 </div>
 
 <script>
   const initCarousel = () => {
-    const carousel = document.currentScript?.parentElement;
-    if (!carousel) return;
-    const imgs = carousel.querySelectorAll('.carousel-img');
-    if (imgs.length === 0) return;
-    let current = 0;
-    const show = () => {
-      imgs.forEach((el, i) => {
-        el.style.display = i === current ? 'block' : 'none';
-      });
-    };
-    show();
-    const prev = carousel.querySelector('.prev');
-    const next = carousel.querySelector('.next');
-
-    prev?.addEventListener('click', () => {
-      current = (current - 1 + imgs.length) % imgs.length;
-      show();
-    });
-    next?.addEventListener('click', () => {
-      current = (current + 1) % imgs.length;
-      show();
-    });
+    const root = document.currentScript?.parentElement;
+    if (!root) return;
+    const splideEl = root.querySelector('.splide');
+    if (!splideEl) return;
+    new Splide(splideEl, { type: 'loop' }).mount();
   };
 
   if (document.readyState === 'loading') {

--- a/src/components/project/ImageCarousel.astro
+++ b/src/components/project/ImageCarousel.astro
@@ -1,7 +1,6 @@
 ---
 import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro:assets';
-import Splide from '@splidejs/splide';
 import '@splidejs/splide/css';
 
 interface Props {
@@ -23,7 +22,9 @@ const { images } = Astro.props;
   </div>
 </div>
 
-<script>
+<script define:vars>
+  import Splide from '@splidejs/splide';
+
   const initCarousel = () => {
     const root = document.currentScript?.parentElement;
     if (!root) return;


### PR DESCRIPTION
## Summary
- add `@splidejs/splide` dependency
- switch the project `ImageCarousel` to use Splide

## Testing
- `pnpm build` *(fails: "The collection \"blog\" does not exist or is empty")*

------
https://chatgpt.com/codex/tasks/task_e_688ba05dded8832f98f0e8ca5e7855c7