### PR TITLE
feat: add project links and update resume layout

### DIFF
--- a/src/components/generic/SummaryCard.astro
+++ b/src/components/generic/SummaryCard.astro
@@ -24,13 +24,13 @@ const {
 
 <Card color='white'>
   <h3 class='poppins text-lg md:text-xl'>{title}</h3>
-  <div class='rounded-lg border-3 border-black my-4 h-56'>
+  <div class='rounded-lg border-3 border-black my-4'>
     <Image
       src={imgSrc}
       alt={imgAlt}
       width={800}
       height={400}
-      class='rounded h-full w-full object-cover'
+      class='rounded w-full h-auto max-h-56 object-contain mx-auto'
     />
   </div>
   <p class='poppins'>{description}</p>

--- a/src/layouts/Project.astro
+++ b/src/layouts/Project.astro
@@ -8,8 +8,10 @@ interface Props {
   description: string;
   images?: ImageMetadata[];
   mainClass?: string;
-  href?: string;
-  linkText?: string;
+  siteHref?: string;
+  siteLinkText?: string;
+  repoHref?: string;
+  repoLinkText?: string;
 }
 
 const {
@@ -17,19 +19,28 @@ const {
   description,
   images = [],
   mainClass = 'bg-blue p-6',
-  href,
-  linkText = 'View site \u2192',
+  siteHref,
+  siteLinkText = 'Visit site \u2192',
+  repoHref,
+  repoLinkText = 'View repo \u2192',
 } = Astro.props;
 ---
 
 <Layout title={title} pageTitle={title} description={description}>
   <main class={mainClass}>
     <h2 class='text-3xl md:text-5xl dm-serif mb-4'>{title}</h2>
-    {href && (
-      <div class='my-4'>
-        <a href={href} class='border-2 border-black px-4 py-2 bg-white card-shadow'>
-          {linkText}
-        </a>
+    {(siteHref || repoHref) && (
+      <div class='my-4 flex gap-4 flex-wrap'>
+        {siteHref && (
+          <a href={siteHref} class='border-2 border-black px-4 py-2 bg-white card-shadow'>
+            {siteLinkText}
+          </a>
+        )}
+        {repoHref && (
+          <a href={repoHref} class='border-2 border-black px-4 py-2 bg-white card-shadow'>
+            {repoLinkText}
+          </a>
+        )}
       </div>
     )}
     {images.length > 0 && <ImageCarousel images={images} />}

--- a/src/pages/projects/careernova/index.astro
+++ b/src/pages/projects/careernova/index.astro
@@ -11,8 +11,7 @@ const images = [careernova1, careernova2];
   description='About Careernova'
   images={images}
   mainClass='bg-blue p-6'
-  href=`https://careernova.com`
-  linkText='Visit site \u2192'
+  siteHref='https://careernova.com'
 >
   <p class='poppins mt-4'>Careernova is a platform for job seekers to tailor their resume to a given job description.</p>
   <p class='poppins mt-4'>I built this project a few months after ChatGPT was released looking for excused to play around with LLMs.</p>

--- a/src/pages/projects/circlepop/index.astro
+++ b/src/pages/projects/circlepop/index.astro
@@ -11,8 +11,8 @@ const images = [circlepop1, circlepop2];
   description='About Circlepop'
   images={images}
   mainClass='bg-blue p-6'
-  href='https://example.com'
-  linkText='Visit site \u2192'
+  siteHref='https://example.com'
+  repoHref='https://github.com/z0d14c/circlepop'
 >
   <p class='poppins mt-4'>This is a stub page for the Circlepop project. More information will be added later.</p>
 </ProjectLayout>

--- a/src/pages/resume/index.astro
+++ b/src/pages/resume/index.astro
@@ -1,106 +1,121 @@
 ---
 import Layout from '@layouts/Default.astro';
 
-interface Line {
+interface Bullet {
   text: string;
   critical?: boolean;
 }
 
+interface Item {
+  title: string;
+  date?: string;
+  bullets: Bullet[];
+}
+
 interface Section {
   title: string;
-  lines: Line[];
+  items: Item[];
 }
 
 const sections: Section[] = [
   {
     title: 'Experience',
-    lines: [
-      { text: 'Jan 2023 - Present', critical: true },
-      { text: 'Freelance - Freelance UI Engineer', critical: true },
-      { text: 'Various', critical: true },
+    items: [
       {
-        text:
-          'Assist various companies with full-stack engineering in service of creating more powerful and usable experiences for their customers. Focused on Typescript, JS, Node- and React-based technologies, while also utilizing other languages like Ruby as needed.',
-      },
-      { text: 'Nov 2018 - June 2022', critical: true },
-      { text: 'Amazon Web Services/Amazon - Frontend Engineer II', critical: true },
-      { text: 'Amazon Web Services (Team: Honeycode / low code platform)', critical: true },
-      {
-        text:
-          'Crafted complex, composable UI components such as ExpressionEditor to enable users to add conditional logic to their applications without writing code; rewrote SlateJS-based text editor widget to support new features such as copy/paste and overall stability, add types',
+        title: 'Freelance - Freelance UI Engineer',
+        date: 'Jan 2023 - Present',
+        bullets: [
+          {
+            text: 'Assist various companies with full-stack engineering in service of creating more powerful and usable experiences for their customers. Focused on Typescript, JS, Node- and React-based technologies, while also utilizing other languages like Ruby as needed.',
+            critical: true,
+          },
+        ],
       },
       {
-        text:
-          'Supervised and mentored junior engineers to write metrics, alarms, and dashboards code, resulting in clear visibility into frontend app performance before and after product launch. Successfully instrumented all major features with associated metrics and alarms achieving visibility into performance used in daily standups and severe event analysis',
+        title: 'Amazon Web Services/Amazon - Frontend Engineer II',
+        date: 'Nov 2018 - June 2022',
+        bullets: [
+          {
+            text: 'Crafted complex, composable UI components such as ExpressionEditor to enable users to add conditional logic to their applications without writing code; rewrote SlateJS-based text editor widget to support new features such as copy/paste and overall stability, add types',
+            critical: true,
+          },
+          {
+            text: 'Supervised and mentored junior engineers to write metrics, alarms, and dashboards code, resulting in clear visibility into frontend app performance before and after product launch. Successfully instrumented all major features with associated metrics and alarms achieving visibility into performance used in daily standups and severe event analysis',
+          },
+          {
+            text: 'Designed and implemented frontend logging and analytics middleware to log Redux actions and parameters using allowlist/blocklist pattern, and influenced the rest of the organization to adopt it. Consequently, debugging high severity events became significantly easier while enabling teams to protect themselves from sensitive data leaks.',
+          },
+          {
+            text: 'Led improvements in keyboard usability and overall accessibility for the product by adding hotkey support and ensuring that every component, including Modals, Tooltips, SkipTo, and the application as a whole was able to be used solely with a keyboard. Additionally, I integrated the component library with an a11y auditor to ensure WCAG A compliance for all components.',
+          },
+          { text: 'Promoted from FEE1 -> FEE2' },
+          {
+            text: 'Designed Figma wireframes, conducted user surveys, and created the technical design for Imperium UI. Successfully transitioned Network Device Automation from a CLI to a UI-based system, impacting thousands of Amazon employees.',
+          },
+          {
+            text: 'Directed the implementation of Imperium UI MVP from scratch and spearheaded key aspects such as device details and overall frontend architecture.',
+          },
+          {
+            text: 'I was heavily involved in hiring and training team members. I participated in ~40 interview loops and mentored team members and interns, including designing their project assignments and onboarding them to our software architectures and systems.',
+          },
+        ],
       },
       {
-        text:
-          'Designed and implemented frontend logging and analytics middleware to log Redux actions and parameters using allowlist/blocklist pattern, and influenced the rest of the organization to adopt it. Consequently, debugging high severity events became significantly easier while enabling teams to protect themselves from sensitive data leaks.',
+        title: 'Igneous Systems - Member of Technical Staff 2 / UX Team Lead',
+        date: 'Sep 2017 - Oct 2018',
+        bullets: [
+          {
+            text: 'Implemented end-to-end testing framework (Cypress) to increase the resilience of the frontend product, ensuring higher quality and better user experience.',
+            critical: true,
+          },
+          { text: 'Delivered redesigned customer dashboard' },
+          {
+            text: 'Led quality increase efforts for UX team, adopting Typescript, linting, codifying standards',
+          },
+          { text: 'Promoted from MTS 1 to MTS 2' },
+        ],
       },
       {
-        text:
-          'Led improvements in keyboard usability and overall accessibility for the product by adding hotkey support and ensuring that every component, including Modals, Tooltips, SkipTo, and the application as a whole was able to be used solely with a keyboard. Additionally, I integrated the component library with an a11y auditor to ensure WCAG A compliance for all components.',
+        title: 'MicaSense - Software Engineer',
+        date: 'Aug 2016 - Jul 2017',
+        bullets: [
+          {
+            text: 'Migrated legacy Backbone.js front-end to a React-Redux stack in just a few months',
+            critical: true,
+          },
+          {
+            text: 'Integrate React-based application with Mapbox-GL to display map graphics/UI integrated with MicaSense tile data for users',
+          },
+          { text: '(+ Internships at Estech Systems and Credera)' },
+        ],
       },
-      { text: 'Promoted from FEE1 -> FEE2' },
-      { text: 'Amazon (Team: Imperium UI)', critical: true },
-      {
-        text:
-          'Designed Figma wireframes, conducted user surveys, and created the technical design for Imperium UI. Successfully transitioned Network Device Automation from a CLI to a UI-based system, impacting thousands of Amazon employees.',
-      },
-      {
-        text:
-          'Directed the implementation of Imperium UI MVP from scratch and spearheaded key aspects such as device details and overall frontend architecture.',
-      },
-      {
-        text:
-          'I was heavily involved in hiring and training team members. I participated in ~40 interview loops and mentored team members and interns, including designing their project assignments and onboarding them to our software architectures and systems.',
-      },
-      { text: 'Sep 2017 - Oct 2018', critical: true },
-      { text: 'Igneous Systems - Member of Technical Staff 2 / UX Team Lead', critical: true },
-      {
-        text:
-          'Implemented end-to-end testing framework (Cypress) to increase the resilience of the frontend product, ensuring higher quality and better user experience.',
-      },
-      { text: 'Delivered redesigned customer dashboard' },
-      {
-        text:
-          'Led quality increase efforts for UX team, adopting Typescript, linting, codifying standards',
-      },
-      { text: 'Promoted from MTS 1 to MTS 2' },
-      { text: 'Aug 2016 - Jul 2017', critical: true },
-      { text: 'MicaSense- Software Engineer', critical: true },
-      {
-        text:
-          'Migrated legacy Backbone.js front-end to a React-Redux stack in just a few months',
-      },
-      {
-        text:
-          'Integrate React-based application with Mapbox-GL to display map graphics/UI integrated with MicaSense tile data for users',
-      },
-      { text: '(+ Internships at Estech Systems and Credera)' },
     ],
   },
   {
     title: 'Projects',
-    lines: [
-      { text: 'Careernova.pro - Automated Cover Letter Generator', critical: true },
+    items: [
       {
-        text:
-          'Full-stack project; uses SST framework (as a means to manage AWS infrastructure), React and Typescript. AI and prompt engineering are used to generate cover letters and resume advice for users.',
+        title: 'Careernova.pro - Automated Cover Letter Generator',
+        bullets: [
+          {
+            text: 'Full-stack project; uses SST framework (as a means to manage AWS infrastructure), React and Typescript. AI and prompt engineering are used to generate cover letters and resume advice for users.',
+            critical: true,
+          },
+        ],
       },
     ],
   },
   {
     title: 'Education',
-    lines: [
+    items: [
       {
-        text: 'University of Texas at Dallas - B.S. Software Engineering',
-        critical: true,
-      },
-      { text: 'focus: Human-Computer Interaction' },
-      {
-        text:
-          'Technical Officer of UX Club, User Researcher in FIVE Lab with Dr. Ryan McMahan',
+        title: 'University of Texas at Dallas - B.S. Software Engineering',
+        bullets: [
+          { text: 'focus: Human-Computer Interaction' },
+          {
+            text: 'Technical Officer of UX Club, User Researcher in FIVE Lab with Dr. Ryan McMahan',
+          },
+        ],
       },
     ],
   },
@@ -108,10 +123,12 @@ const sections: Section[] = [
 
 const abridged = sections.map((section) => ({
   ...section,
-  lines: section.lines.filter((l) => l.critical),
+  items: section.items.map((item) => ({
+    ...item,
+    bullets: item.bullets.filter((b) => b.critical),
+  })),
 }));
 ---
-
 <Layout title='Resume' pageTitle='Resume' description='Thomas Augustus Grice Resume'>
   <main class='bg-yellow p-6'>
     <h2 class='text-3xl md:text-5xl dm-serif'>Resume</h2>
@@ -124,11 +141,21 @@ const abridged = sections.map((section) => ({
       {abridged.map((section) => (
         <div class='mt-4'>
           <h4 class='text-xl dm-serif'>{section.title}</h4>
-          <ul class='list-disc pl-4'>
-            {section.lines.map((line) => (
-              <li class='poppins'>{line.text}</li>
-            ))}
-          </ul>
+          {section.items.map((item) => (
+            <div class='mt-2'>
+              <h5 class='poppins font-semibold'>
+                {item.title}
+                {item.date && <span class='font-normal'> - {item.date}</span>}
+              </h5>
+              {item.bullets.length > 0 && (
+                <ul class='list-disc pl-4'>
+                  {item.bullets.map((line) => (
+                    <li class='poppins'>{line.text}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))}
         </div>
       ))}
     </section>
@@ -137,11 +164,19 @@ const abridged = sections.map((section) => ({
       {sections.map((section) => (
         <div class='mt-4'>
           <h4 class='text-xl dm-serif'>{section.title}</h4>
-          <ul class='list-disc pl-4'>
-            {section.lines.map((line) => (
-              <li class='poppins'>{line.text}</li>
-            ))}
-          </ul>
+          {section.items.map((item) => (
+            <div class='mt-2'>
+              <h5 class='poppins font-semibold'>
+                {item.title}
+                {item.date && <span class='font-normal'> - {item.date}</span>}
+              </h5>
+              <ul class='list-disc pl-4'>
+                {item.bullets.map((line) => (
+                  <li class='poppins'>{line.text}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
       ))}
     </section>
@@ -163,3 +198,4 @@ const abridged = sections.map((section) => ({
     });
   </script>
 </Layout>
+


### PR DESCRIPTION
## Summary
- add optional site and repo links for project pages
- restructure resume sections with subheaders and bullet points
- ensure project thumbnails scale without cropping

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6894524a21f8832fa1c150393df55fc8