### PR TITLE
feat: make project descriptions data-driven

### DIFF
--- a/src/layouts/Project.astro
+++ b/src/layouts/Project.astro
@@ -12,6 +12,7 @@ interface Props {
   siteLinkText?: string;
   repoHref?: string;
   repoLinkText?: string;
+  paragraphs?: string[];
 }
 
 const {
@@ -23,6 +24,7 @@ const {
   siteLinkText = "Visit site \u2192",
   repoHref,
   repoLinkText = "View source \u2192",
+  paragraphs = [],
 } = Astro.props;
 ---
 
@@ -52,6 +54,19 @@ const {
       )
     }
     {images.length > 0 && <ImageCarousel images={images} />}
+    {
+      paragraphs.length > 0 && (
+        <section class="mx-auto max-w-6xl px-6 py-10 md:py-14">
+          <article class="mx-auto mt-10 max-w-prose rounded-2xl bg-white/70 px-6 py-6 leading-relaxed shadow-sm backdrop-blur-sm">
+            <div class="prose prose-neutral lg:prose-lg">
+              {paragraphs.map((p) => (
+                <p set:html={p} />
+              ))}
+            </div>
+          </article>
+        </section>
+      )
+    }
     <slot />
   </main>
 </Layout>

--- a/src/pages/projects/careernova/index.astro
+++ b/src/pages/projects/careernova/index.astro
@@ -4,38 +4,21 @@ import careernova1 from "@assets/projects/careernova1.png";
 import careernova2 from "@assets/projects/careernova2.png";
 
 const images = [careernova1, careernova2];
+
+const paragraphs = [
+  "<strong>Careernova</strong> is a platform for job seekers to tailor their resume to a given job description.",
+  "I built it a few months after ChatGPT launched to experiment with LLMs, combining resume critique/tailoring with cover-letter generation.",
+  "Challenge: handling LLM non-determinism (this was early, pre-established practices). I used one/few-shot prompting with reasonable effect; next step would have been a retry/backoff mechanism.",
+  "UI detail: using <code>&lt;mark&gt;</code> to highlight critiques and suggestions from the LLM output.",
+];
 ---
 
 <ProjectLayout
   title="Careernova"
   description="About Careernova"
   images={images}
-  mainClass="bg-blue p-6"
+  mainClass="bg-blue"
   siteHref="https://careernova.com"
   repoHref="https://github.com/z0d14c/careernova"
->
-  <p class="poppins mt-4">
-    Careernova is a platform for job seekers to tailor their resume to a given
-    job description.
-  </p>
-  <p class="poppins mt-4">
-    I built this project a few months after ChatGPT was released looking for
-    excused to play around with LLMs.
-  </p>
-  <p class="poppins mt-4">
-    I was interested in combining the feature of critiquing/tailoring resumes
-    along with writing cover letters.
-  </p>
-  <p class="poppins mt-4">
-    One challenge was dealing with the non-determinism of LLMs. This was early
-    on before best practices had been established.
-  </p>
-  <p class="poppins mt-4">
-    I used one/few-shot prompting to reasonable effect. The next thing I would
-    have added is probably a retry mechanism, although I never got around to it.
-  </p>
-  <p class="poppins mt-4">
-    The UI also had some interesting details, using {`<mark>`}s to highlight the
-    critique and suggestions based on LLM output.
-  </p>
-</ProjectLayout>
+  paragraphs={paragraphs}
+/>

--- a/src/pages/projects/circlepop/index.astro
+++ b/src/pages/projects/circlepop/index.astro
@@ -4,18 +4,18 @@ import circlepop1 from "@assets/projects/circlepop1.png";
 import circlepop2 from "@assets/projects/circlepop2.png";
 
 const images = [circlepop1, circlepop2];
+
+const paragraphs = [
+  "This is a stub page for the Circlepop project. More information will be added later.",
+];
 ---
 
 <ProjectLayout
   title="Circlepop"
   description="About Circlepop"
   images={images}
-  mainClass="bg-blue p-6"
+  mainClass="bg-blue"
   siteHref="https://example.com"
   repoHref="https://github.com/z0d14c/circlepop"
->
-  <p class="poppins mt-4">
-    This is a stub page for the Circlepop project. More information will be
-    added later.
-  </p>
-</ProjectLayout>
+  paragraphs={paragraphs}
+/>


### PR DESCRIPTION
## Summary
- allow `ProjectLayout` to render paragraphs from data
- switch careernova and circlepop pages to pass description arrays

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68950d1a8498832fa492ee2ea50be948