### PR TITLE
feat: improve resume print layout

### DIFF
--- a/src/components/layout/BaseFooter.astro
+++ b/src/components/layout/BaseFooter.astro
@@ -11,7 +11,7 @@ const { backToTop = false } = Astro.props;
     <button
       class:list={[
         backToTop ? `backToTop` : null,
-        'transition-300 z-50 opacity-0 fixed flex bottom-[10px] right-[30px] w-10 h-10 bg-white border border-black card-shadow',
+        'transition-300 z-50 opacity-0 fixed flex bottom-[10px] right-[30px] w-10 h-10 bg-white border border-black card-shadow print:hidden',
       ]}
     >
       <svg
@@ -33,7 +33,7 @@ const { backToTop = false } = Astro.props;
   )
 }
 
-<footer class='bg-black text-white p-6'>
+<footer class='bg-black text-white p-6 print:hidden'>
   <h2 class='hidden'>Footer</h2>
   <!-- <p class='outfit'>
     Brutal theme for Astro - by <a

--- a/src/components/layout/BaseNavigation.astro
+++ b/src/components/layout/BaseNavigation.astro
@@ -30,7 +30,7 @@ const socialIcons = [
 const { pageTitle } = Astro.props;
 ---
 
-<header class='border-b-4 border-black flex justify-between p-6 items-center'>
+<header class='border-b-4 border-black flex justify-between p-6 items-center print:hidden'>
   {pageTitle && <h1 class='hidden'>{pageTitle}</h1>}
   <a href='/' title='Back to Home'>
     <p class='righteous md:text-5xl'>Thomas Augustus Grice</p>

--- a/src/components/resume/ResumeToggle.tsx
+++ b/src/components/resume/ResumeToggle.tsx
@@ -48,9 +48,15 @@ export default function ResumeToggle({ sections, abridged }: Props) {
   );
 
   return (
-    <main className="bg-yellow p-6">
-      <h2 className="text-3xl md:text-5xl dm-serif">Resume</h2>
-      <div className="my-4">
+    <main className="bg-yellow p-6 print:bg-white">
+      <div className="hidden print:block mb-4">
+        <h1 className="text-xl font-bold">Thomas Augustus Grice</h1>
+        <p>Austin, TX</p>
+        <p>github.com/z0d14c</p>
+        <p>grice.city</p>
+      </div>
+      <h2 className="text-3xl md:text-5xl dm-serif print:hidden">Resume</h2>
+      <div className="my-4 print:hidden">
         <button
           onClick={() => setShowDetailed((d) => !d)}
           className="border-2 border-black px-4 py-2 bg-white card-shadow"


### PR DESCRIPTION
## Summary
- hide navigation and footer when printing
- add print-only contact information on resume

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689a45448f24832fad8077153f4f9a13