### PR TITLE
feat: share project data and enhance resume page

### DIFF
--- a/src/components/resume/ResumeToggle.tsx
+++ b/src/components/resume/ResumeToggle.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState } from "react";
 
 interface Bullet {
   text: string;
@@ -28,9 +28,11 @@ export default function ResumeToggle({ sections, abridged }: Props) {
       {list.map((section) => (
         <div className="mt-4" key={section.title}>
           <h4 className="text-xl dm-serif">{section.title}</h4>
-          {section.entries.map((entry) => (
-            <div className="mt-2" key={entry.title}>
-              <h5 className="poppins font-semibold">{entry.title}</h5>
+          {section.entries.map((entry, i) => (
+            <div className="mt-2" key={entry.title || i}>
+              {entry.title && (
+                <h5 className="poppins font-semibold">{entry.title}</h5>
+              )}
               {entry.bullets.length > 0 && (
                 <ul className="list-disc pl-4">
                   {entry.bullets.map((b, i) => (
@@ -48,7 +50,7 @@ export default function ResumeToggle({ sections, abridged }: Props) {
   );
 
   return (
-    <main className="bg-yellow p-6 print:bg-white">
+    <main className="bg-yellow p-6 print:bg-white max-w-3xl mx-auto print:max-w-full">
       <div className="hidden print:block mb-4">
         <h1 className="text-xl font-bold">Thomas Augustus Grice</h1>
         <p>Austin, TX</p>
@@ -61,7 +63,7 @@ export default function ResumeToggle({ sections, abridged }: Props) {
           onClick={() => setShowDetailed((d) => !d)}
           className="border-2 border-black px-4 py-2 bg-white card-shadow"
         >
-          {showDetailed ? 'Show abridged resume' : 'Show detailed resume'}
+          {showDetailed ? "Show abridged resume" : "Show detailed resume"}
         </button>
       </div>
       {showDetailed ? (

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,27 @@
+import careernovaImg from "@assets/projects/careernova1.png";
+import circlepopImg from "@assets/projects/circlepop1.png";
+import type { ImageMetadata } from "astro:assets";
+
+export interface Project {
+  title: string;
+  slug: string;
+  description: string;
+  img: ImageMetadata;
+}
+
+export const projects: Project[] = [
+  {
+    title: "Circlepop",
+    slug: "circlepop",
+    description:
+      "Proof of concept for a transit and population density map within a given radius",
+    img: circlepopImg,
+  },
+  {
+    title: "Careernova",
+    slug: "careernova",
+    description:
+      "A platform for job seekers to tailor their resume to a given job description",
+    img: careernovaImg,
+  },
+];

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,29 +1,17 @@
 ---
-import Layout from '@layouts/Default.astro';
-import SummaryCard from '@components/generic/SummaryCard.astro';
-import careernovaImg from '@assets/projects/careernova1.png';
-import circlepopImg from '@assets/projects/circlepop1.png';
-
-const projects = [
-  {
-    title: 'Circlepop',
-    description: 'Proof of concept for a transit and population density map within a given radius',
-    img: circlepopImg,
-    slug: 'circlepop',
-  },
-  {
-    title: 'Careernova',
-    description: 'A platform for job seekers to tailor their resume to a given job description',
-    img: careernovaImg,
-    slug: 'careernova',
-  },
-];
+import Layout from "@layouts/Default.astro";
+import SummaryCard from "@components/generic/SummaryCard.astro";
+import { projects } from "@data/projects";
 ---
 
-<Layout title='Projects' pageTitle='Software Projects' description='Software projects by Thomas Augustus Grice'>
-  <main class='bg-purple p-6'>
-    <h2 class='text-3xl md:text-5xl dm-serif mb-4'>Software Projects</h2>
-    <ul class='grid md:grid-cols-2 gap-8'>
+<Layout
+  title="Projects"
+  pageTitle="Software Projects"
+  description="Software projects by Thomas Augustus Grice"
+>
+  <main class="bg-purple p-6">
+    <h2 class="text-3xl md:text-5xl dm-serif mb-4">Software Projects</h2>
+    <ul class="grid md:grid-cols-2 gap-8">
       {
         projects.map((proj) => (
           <li>
@@ -33,7 +21,7 @@ const projects = [
               imgAlt={proj.title}
               description={proj.description}
               href={`/projects/${proj.slug}/`}
-              linkText='View project \u2192'
+              linkText="View project \u2192"
             />
           </li>
         ))

--- a/src/pages/resume/index.astro
+++ b/src/pages/resume/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "@layouts/Default.astro";
 import ResumeToggle from "@components/resume/ResumeToggle.tsx";
+import { projects } from "@data/projects";
 
 interface Bullet {
   text: string;
@@ -21,8 +22,9 @@ const sections: Section[] = [
   {
     title: "Experience",
     entries: [
-    {
-        title: "Stoke Space Technology - Senior Software Engineer (Jun 2023 - Jun 2025)",
+      {
+        title:
+          "Stoke Space Technology - Senior Software Engineer (Jun 2023 - Jun 2025)",
         bullets: [
           {
             text: "Lead rewrite of inventory subsystem, converting it to a concurrency-safe, service-oriented architecture to support lot-based metadata among other features",
@@ -38,12 +40,12 @@ const sections: Section[] = [
           },
           {
             text: "Design and implement inventory BOM tree traversal and export functionality, including BOM export UI and circular dependency detection",
-            critical: true
+            critical: true,
           },
           {
             text: "Assist rewrite of workplan instruction platform, including multiselect, copy-paste, and concurrency safety",
             critical: true,
-          }
+          },
         ],
       },
       {
@@ -56,8 +58,7 @@ const sections: Section[] = [
         ],
       },
       {
-        title:
-          "Frontend Engineer II - Amazon and AWS (Nov 2018 - Jun 2022)",
+        title: "Frontend Engineer II - Amazon and AWS (Nov 2018 - Jun 2022)",
         bullets: [
           {
             text: "Crafted complex, composable UI components such as ExpressionEditor to enable users to add conditional logic to their applications without writing code; rewrote SlateJS-based text editor widget to support new features such as copy/paste and overall stability, add types",
@@ -80,7 +81,7 @@ const sections: Section[] = [
           },
           {
             text: "Heavily involved in hiring and training team members, participating in ~40 interview loops and mentoring team members and interns, including designing their project assignments and onboarding them to our software architectures and systems.",
-            critical: true
+            critical: true,
           },
         ],
       },
@@ -115,27 +116,25 @@ const sections: Section[] = [
     ],
   },
   {
-    title: "Projects",
+    title: "Skills",
     entries: [
       {
-        title: "Careernova.pro - Automated Cover Letter Generator",
+        title: "",
         bullets: [
           {
-            text: "Full-stack project; uses SST framework (as a means to manage AWS infrastructure), React and Typescript. AI and prompt engineering are used to generate cover letters and resume advice for users.",
+            text: "NodeJS, Javascript, Typescript, AWS, Mapbox, Leaflet, Postgres, Graphql, Redux, Prisma, SQL, CSS, HTML, Web, e2e/unit/integration testing",
             critical: true,
           },
         ],
       },
-      {
-          title: "Circlepop - Transit and Population Within A Circle",
-          bullets: [
-            {
-              text: "Full-stack project using React along with Neon to host PostGRES and Vercel to host the frontend. Reveals population and transit stop data within a given circle.",
-              critical: true,
-            },
-        ],
-        }
     ],
+  },
+  {
+    title: "Projects",
+    entries: projects.map((p) => ({
+      title: p.title,
+      bullets: [{ text: p.description, critical: true }],
+    })),
   },
   {
     title: "Education",
@@ -146,7 +145,7 @@ const sections: Section[] = [
           { text: "focus: Human-Computer Interaction" },
           {
             text: "Technical Officer of UX Club, User Researcher in FIVE Lab with Dr. Ryan McMahan",
-            critical: true
+            critical: true,
           },
         ],
       },
@@ -168,9 +167,5 @@ const abridged = sections.map((section) => ({
   pageTitle="Resume"
   description="Thomas Augustus Grice Resume"
 >
-  <ResumeToggle
-    sections={sections}
-    abridged={abridged}
-    client:only="react"
-  />
+  <ResumeToggle sections={sections} abridged={abridged} client:only="react" />
 </Layout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
       "@components/*": ["src/components/*"],
       "@layouts/*": ["src/layouts/*"],
       "@pages/*": ["src/pages/*"],
-      "@assets/*": ["src/assets/*"]
+      "@assets/*": ["src/assets/*"],
+      "@data/*": ["src/data/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- centralize project metadata in a reusable data file
- add Skills section to resume and generate project entries from shared data
- tighten resume layout and hide empty entry headings

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_689a6b8510d4832f80280b8f1e45f018